### PR TITLE
Add payload extending by zero bytes

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -24,7 +24,7 @@ func TestSendInfo(t *testing.T) {
 	serverEndPoint := "localhost:8888"
 	reportInterval := 5
 	podName := "test-pod"
-	_, err := sendInfo(serverEndPoint, podName, reportInterval, fakeClient)
+	_, err := sendInfo(serverEndPoint, podName, reportInterval, false, fakeClient)
 	if err != nil {
 		t.Errorf("sendInfo should not return error. Details: %v", err)
 	}
@@ -62,7 +62,12 @@ func TestSendInfo(t *testing.T) {
 		t.Errorf("Error should not occur while unmarshaling fake request's payload. Details: %v", err)
 	}
 
-	if expectedIPs := linkV4Info(); !reflect.DeepEqual(expectedIPs, payload.IPs) {
+	iproc := &IfaceProcessor{}
+	expectedIPs, err := iproc.ProcessIifaces()
+	if err != nil {
+		t.Errorf("Error should not occured while retrieving expected ifaces. Details: %v", err)
+	}
+	if !reflect.DeepEqual(expectedIPs, payload.IPs) {
 		t.Errorf("IPs data from payload is not as expected. expected %v\n actual %v", expectedIPs, payload.IPs)
 	}
 
@@ -73,5 +78,10 @@ func TestSendInfo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(payload.LookupHost, map[string][]string{expectedHost: addrs}) {
 		t.Errorf("LookupHost data from the payload is not as expected")
+	}
+
+	if payload.ZeroExtenderLength != 0 {
+		t.Errorf("ZeroExtenderLength should be %v instead it is %v",
+			0, payload.ZeroExtenderLength)
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: 2554967efad44d14a144d03f74ef0bdca36445961ac7b634ce0216e64f65f179
-updated: 2017-01-12T16:32:26.613410188+02:00
+hash: d6a85b0c0bbaa43dec026d2be9c7581535e248179e211fbe496cd9a643d2c26c
+updated: 2017-02-08T13:06:11.655824473+02:00
 imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+- name: github.com/vishvananda/netlink
+  version: dbc72376c86301bb873c332830857e73c9f701e3
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
-hash: d6a85b0c0bbaa43dec026d2be9c7581535e248179e211fbe496cd9a643d2c26c
-updated: 2017-02-08T13:06:11.655824473+02:00
+hash: f1bd13154c0aa1c4d5d0143238ce7533f04aa24f8b9868d2bf7b64438c7e9fa7
+updated: 2017-02-08T18:16:11.385410512+02:00
 imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/vishvananda/netlink
   version: dbc72376c86301bb873c332830857e73c9f701e3
+  subpackages:
+  - nl
+- name: github.com/vishvananda/netns
+  version: 2c9454e4fc6e2edc1a1c84e64ed3d6e662fb6991
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,4 @@
 package: github.com/Mirantis/k8s-netchecker-agent
 import:
 - package: github.com/golang/glog
+- package: github.com/vishvananda/netlink

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,4 @@ package: github.com/Mirantis/k8s-netchecker-agent
 import:
 - package: github.com/golang/glog
 - package: github.com/vishvananda/netlink
+- package: github.com/vishvananda/netns


### PR DESCRIPTION
In case the agent's data is smaller than MTU value the network checker
will not be able to detect problems with packet fragmentation. Special
parameter is added for CLI which triggers a procedure that finds out MTU value
of the link in communication with the server and extends marshaled
payload by zero bytes slice of that value length.