### PR TITLE
Setup CI for end-to-end test and automate docker push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: required
+services:
+  - docker
 language: go
 go:
   - 1.7.x
-before_install: mkdir $GOPATH/bin && curl https://glide.sh/get | sh
-install: make get-deps
-script: make test-local
+install:
+  - make get-deps
+script:
+  - make unit
+  - make docker-publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM busybox
 
 MAINTAINER Artem Roma <aroma@mirantis.com>
@@ -5,5 +19,4 @@ MAINTAINER Artem Roma <aroma@mirantis.com>
 COPY _output/agent /usr/bin/netchecker-agent
 
 ENTRYPOINT ["netchecker-agent", "-logtostderr"]
-
 CMD ["-v=5"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-FROM golang:1.7-alpine
-
-MAINTAINER Artem Roma <aroma@mirantis.com>
-
-RUN apk add --update bash
-
-WORKDIR /go/src/github.com/Mirantis/k8s-netchecker-agent

--- a/agent.go
+++ b/agent.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/helm-chart/netchecker-agent/values.yaml
+++ b/helm-chart/netchecker-agent/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: quay.io/l23network/k8s-netchecker-agent
+  repository: mirantis/k8s-netchecker-agent
   tag: latest
   pullPolicy: Always
 

--- a/scripts/build_image_server_or_agent.sh
+++ b/scripts/build_image_server_or_agent.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+NETCHECKER_REPO=${NETCHECKER_REPO:-}
+NETCHECKER_BRANCH=${NETCHECKER_BRANCH:-master}
+
+
+function build-image-server-or-agent {
+  if [ -z "${NETCHECKER_REPO}" ]; then
+  	echo "NETCHECKER_REPO is not set!"
+  	exit 1
+  else
+      pushd "../" &> /dev/null
+      if [ ! -d "${NETCHECKER_REPO}" ]; then
+        git clone --branch "${NETCHECKER_BRANCH}" \
+            --depth 1 --single-branch "https://github.com/Mirantis/${NETCHECKER_REPO}.git"
+      fi
+  fi
+  pushd "./${NETCHECKER_REPO}" &> /dev/null
+  make build-image
+  popd &> /dev/null
+  popd &> /dev/null
+}
+
+build-image-server-or-agent

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-}
+TRAVIS_TEST_RESULT=${TRAVIS_TEST_RESULT:-}
+TRAVIS_BRANCH=${TRAVIS_BRANCH:-}
+IMAGE_REPO=${IMAGE_REPO:-}
+TRAVIS_TAG=${TRAVIS_TAG:-}
+
+
+function push-to-docker {
+  if [ -z "${TRAVIS_TEST_RESULT}" ]; then
+    echo "TRAVIS_TEST_RESULT is not set!"
+    exit 1
+  else
+      if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
+        echo "Some of the previous steps ended with an errors! The build is broken!"
+        exit 1
+      fi
+  fi
+
+  if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ]; then
+    echo "Processing PR ${TRAVIS_PULL_REQUEST_BRANCH}"
+    exit 0
+  else
+      set +o xtrace
+      docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+      set -o xtrace
+  fi
+
+  if [ -z "${IMAGE_REPO}" ]; then
+    echo "IMAGE_REPO is not set!"
+    exit 1
+  fi
+
+  if [ ! -z "${TRAVIS_TAG}" ]; then
+    echo "Pushing with tag - ${TRAVIS_TAG}"
+    docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    docker push "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    exit
+  fi
+
+  if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    echo "Pushing with tag - latest"
+    docker push "${IMAGE_REPO}":latest
+    exit
+  fi
+
+  echo "Pushing with tag - ${TRAVIS_BRANCH}"
+  docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
+  docker push "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
+}
+
+push-to-docker

--- a/scripts/import_images.sh
+++ b/scripts/import_images.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+IMAGE_REPO_SERVER=${IMAGE_REPO_SERVER:-mirantis/k8s-netchecker-server}
+IMAGE_REPO_AGENT=${IMAGE_REPO_AGENT:-mirantis/k8s-netchecker-agent}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+NUM_NODES=${NUM_NODES:-3}
+TMP_IMAGE_PATH=${TMP_IMAGE_PATH:-/tmp/netchecker-all.tar}
+# export MASTER_NAME=kube-master if you need
+# to import images in kube-master node
+MASTER_NAME=${MASTER_NAME:-}
+SLAVE_NAME=${SLAVE_NAME:-"kube-node-"}
+
+
+function import-images {
+	docker save -o "${TMP_IMAGE_PATH}" \
+	"${IMAGE_REPO_SERVER}":"${IMAGE_TAG}" "${IMAGE_REPO_AGENT}":"${IMAGE_TAG}"
+
+    if [ ! -z "${MASTER_NAME}" ]; then
+      docker cp "${TMP_IMAGE_PATH}" "${MASTER_NAME}":/netchecker-all.tar
+      docker exec -ti "${MASTER_NAME}" docker load -i /netchecker-all.tar
+      docker exec -ti "${MASTER_NAME}" docker images
+    fi
+
+    for node in $(seq 1 "${NUM_NODES}"); do
+      docker cp "${TMP_IMAGE_PATH}" "${SLAVE_NAME}""${node}":/netchecker-all.tar
+      docker exec -ti "${SLAVE_NAME}""${node}" docker load -i /netchecker-all.tar
+      docker exec -ti "${SLAVE_NAME}""${node}" docker images
+    done
+    echo "Finished copying docker images to dind nodes"
+}
+
+import-images

--- a/scripts/kubeadm_dind_cluster.sh
+++ b/scripts/kubeadm_dind_cluster.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+NUM_NODES=${NUM_NODES:-3}
+KUBEADM_SCRIPT_URL=${KUBEADM_SCRIPT_URL:-https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster}
+# kubeadm-dind-cluster supports k8s versions:
+# "v1.4", "v1.5" and "v1.6".
+DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.5}
+
+
+function kubeadm-dind-cluster {
+  pushd "./scripts" &> /dev/null
+  wget "${KUBEADM_SCRIPT_URL}-${DIND_CLUSTER_VERSION}.sh"
+  chmod +x ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh
+  NUM_NODES="${NUM_NODES}" bash ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh down
+  NUM_NODES="${NUM_NODES}" bash ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh up
+  popd &> /dev/null
+}
+
+kubeadm-dind-cluster


### PR DESCRIPTION
- Automate infrastructure setting up for end-to-end
  tests on Travis CI

- Automate docker image building and publishing for
  network checker projects

- Add copyright notices

- Setup helm-chart at new images

Fixes #8