### PR TITLE
Introduce http probing

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -83,6 +83,7 @@ func sendInfo(srvEndpoint, podName string, nodeName string, probeRes []ProbeResu
 		Path:   strings.Join([]string{NetcheckerAgentsEndpoint, podName}, "/"),
 	}).String()
 
+	glog.V(10).Infof("Probes result before marshaling: %v", probeRes)
 	payload := &Payload{
 		HostDate:       time.Now(),
 		IPs:            linkV4Info(),
@@ -157,7 +158,7 @@ func httpProbe(url string, probeRes *ProbeResult, timeout time.Duration) {
 	curRes := new(ProbeResult)
 	curRes.URL = url
 	curRes.Result = 0
-	probeRes = curRes
+	*probeRes = *curRes
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -193,6 +194,7 @@ func httpProbe(url string, probeRes *ProbeResult, timeout time.Duration) {
 	curRes.ServerProcessing = int(result.ServerProcessing / time.Millisecond)
 	curRes.TCPConnection = int(result.TCPConnection / time.Millisecond)
 	curRes.Result = 1
+	*probeRes = *curRes
 
 	// keep variables order
 	fields := []string{"Total", "ContentTransfer", "Connect", "DNSLookup", "ServerProcessing",
@@ -263,7 +265,7 @@ func main() {
 	client := &http.Client{}
 	for {
 		for idx, reqUrl := range probeUrls {
-			go httpProbe(reqUrl, &probeRes[idx], time.Duration(reportInterval-1)*time.Second)
+			go httpProbe(reqUrl, &(probeRes[idx]), time.Duration(reportInterval-1)*time.Second)
 		}
 		glog.V(4).Infof("Sleep for %v second(s)", reportInterval)
 		time.Sleep(time.Duration(reportInterval) * time.Second)

--- a/agent.go
+++ b/agent.go
@@ -255,12 +255,12 @@ func main() {
 	probeUrls := strings.FieldsFunc(probeUrlsArg, func(r rune) bool {
 		return r == ',' || r == ';'
 	})
-	serverUrl := (&url.URL{
+	serverURL := (&url.URL{
 		Scheme: "http",
 		Host:   serverEndpoint,
 		Path:   NetcheckerProbeEndpoint,
 	}).String()
-	probeUrls = append(probeUrls, serverUrl)
+	probeUrls = append(probeUrls, serverURL)
 	probeRes := make([]ProbeResult, len(probeUrls))
 
 	netTransport := &http.Transport{DisableKeepAlives: true}
@@ -270,8 +270,8 @@ func main() {
 	}
 
 	for {
-		for idx, reqUrl := range probeUrls {
-			go httpProbe(reqUrl, &(probeRes[idx]), httpClient)
+		for idx, probeURL := range probeUrls {
+			go httpProbe(probeURL, &(probeRes[idx]), httpClient)
 		}
 		glog.V(4).Infof("Sleep for %v second(s)", reportInterval)
 		time.Sleep(time.Duration(reportInterval) * time.Second)

--- a/agent.go
+++ b/agent.go
@@ -37,9 +37,9 @@ const (
 	EnvVarPodName = "MY_POD_NAME"
 	// EnvVarNodeName is a node name variable in pod's environment
 	EnvVarNodeName = "MY_NODE_NAME"
-	// NetcheckerAgentsEndpoint is a server URL where keepalive message is sent to
+	// NetcheckerAgentsEndpoint is a server URI where keepalive message is sent to
 	NetcheckerAgentsEndpoint = "/api/v1/agents"
-	// NetcheckerProbeEndpoint
+	// NetcheckerProbeEndpoint is a server URI that just provides simple 200 answer
 	NetcheckerProbeEndpoint = "/api/v1/ping"
 )
 
@@ -147,7 +147,7 @@ func linkV4Info() map[string][]string {
 	return result
 }
 
-func http_probe(endpoints []string, probeRes []ProbeResult, timeout time.Duration) {
+func httpProbe(endpoints []string, probeRes []ProbeResult, timeout time.Duration) {
 	for idx, ep := range endpoints {
 		reqURL := (&url.URL{
 			Scheme: "http",
@@ -229,7 +229,7 @@ func main() {
 	endPoints := []string{serverEndpoint}
 	client := &http.Client{}
 	for {
-		go http_probe(endPoints, probeRes, time.Duration(reportInterval-1)*time.Second)
+		go httpProbe(endPoints, probeRes, time.Duration(reportInterval-1)*time.Second)
 		glog.V(4).Infof("Sleep for %v second(s)", reportInterval)
 		time.Sleep(time.Duration(reportInterval) * time.Second)
 

--- a/agent.go
+++ b/agent.go
@@ -147,7 +147,7 @@ func linkV4Info() map[string][]string {
 	return result
 }
 
-func http_probe(endpoints []string, probeRes []ProbeResult) {
+func http_probe(endpoints []string, probeRes []ProbeResult, timeout time.Duration) {
 	for idx, ep := range endpoints {
 		reqURL := (&url.URL{
 			Scheme: "http",
@@ -166,6 +166,7 @@ func http_probe(endpoints []string, probeRes []ProbeResult) {
 		req = req.WithContext(ctx)
 
 		client := http.DefaultClient
+		client.Timeout = timeout
 		res, err := client.Do(req)
 		if err != nil {
 			glog.Fatal(err)
@@ -228,7 +229,7 @@ func main() {
 	endPoints := []string{serverEndpoint}
 	client := &http.Client{}
 	for {
-		go http_probe(endPoints, probeRes)
+		go http_probe(endPoints, probeRes, time.Duration(reportInterval-1)*time.Second)
 		glog.V(4).Infof("Sleep for %v second(s)", reportInterval)
 		time.Sleep(time.Duration(reportInterval) * time.Second)
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -41,7 +41,7 @@ func TestSendInfo(t *testing.T) {
 	podName := "test-pod"
 	extenderLength := 100
 	netProbes := []ProbeResult{
-		{"0.0.0.0:8081", 50, 1, 0, 0, 0, 0},
+		{"0.0.0.0:8081", 1, 50, 1, 0, 0, 0, 0},
 	}
 	_, err := sendInfo(serverEndPoint, podName, nodeName, netProbes, reportInterval, extenderLength, fakeClient)
 	if err != nil {

--- a/agent_test.go
+++ b/agent_test.go
@@ -40,7 +40,10 @@ func TestSendInfo(t *testing.T) {
 	nodeName := strings.Split(serverEndPoint, ":")[0]
 	podName := "test-pod"
 	extenderLength := 100
-	_, err := sendInfo(serverEndPoint, podName, nodeName, reportInterval, extenderLength, fakeClient)
+	netProbes := []ProbeResult{
+		{"0.0.0.0:8081", 50, 1},
+	}
+	_, err := sendInfo(serverEndPoint, podName, nodeName, netProbes, reportInterval, extenderLength, fakeClient)
 	if err != nil {
 		t.Errorf("sendInfo should not return error. Details: %v", err)
 	}
@@ -97,5 +100,8 @@ func TestSendInfo(t *testing.T) {
 	}
 	if payload.NodeName != nodeName {
 		t.Errorf("Node name from payload (%v) does not match expected one (%v)", payload.NodeName, nodeName)
+	}
+	if !reflect.DeepEqual(payload.NetworkProbes, netProbes) {
+		t.Errorf("NetworkProbes data from the payload is not as expected")
 	}
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -41,7 +41,7 @@ func TestSendInfo(t *testing.T) {
 	podName := "test-pod"
 	extenderLength := 100
 	netProbes := []ProbeResult{
-		{"0.0.0.0:8081", 50, 1},
+		{"0.0.0.0:8081", 50, 1, 0, 0, 0, 0},
 	}
 	_, err := sendInfo(serverEndPoint, podName, nodeName, netProbes, reportInterval, extenderLength, fakeClient)
 	if err != nil {

--- a/examples/agent_daemonset.yml
+++ b/examples/agent_daemonset.yml
@@ -28,7 +28,7 @@ spec:
             - "-alsologtostderr=true"
             - "-serverendpoint=netchecker-service:8081"
             - "-reportinterval=60"
-            - "-probeurls=http://10.233.0.1:443/"
+            - "-probeurls=http://ipinfo.io"
           imagePullPolicy: Always
       nodeSelector:
         netchecker: agent

--- a/examples/agent_daemonset.yml
+++ b/examples/agent_daemonset.yml
@@ -28,6 +28,7 @@ spec:
             - "-alsologtostderr=true"
             - "-serverendpoint=netchecker-service:8081"
             - "-reportinterval=60"
+            - "-probeurls=http://10.233.0.1:443/"
           imagePullPolicy: Always
       nodeSelector:
         netchecker: agent

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: 2554967efad44d14a144d03f74ef0bdca36445961ac7b634ce0216e64f65f179
-updated: 2017-01-12T16:32:26.613410188+02:00
+hash: c37496539577ed2757533ba06e9fd94ec11bd71be3e3c556d05c93013751ed1c
+updated: 2017-05-08T13:50:59.697335135+03:00
 imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+- name: github.com/tcnksm/go-httpstat
+  version: ae0d799e7ee65d3dc46d7272368daa830aef6c5a
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,5 @@
 package: github.com/Mirantis/k8s-netchecker-agent
 import:
 - package: github.com/golang/glog
+- package: github.com/tcnksm/go-httpstat
+  version: v0.2.0


### PR DESCRIPTION
Introduces http probing.

The agents are now able to measure the duration of http requests that are sent to netchecker-server and to other hosts by URL provided via command-line argument "probeurls". "probeurls" can hold several URLs divided with ";" or ",". Measurement is implemented using "github.com/tcnksm/go-httpstat" library. Measurements for the each http host are done with "reportinterval" interval (http probes are started simultaneously for all the hosts). In order to get comparable results for every measurement connection is closed after every single probe completion.

Result of each probe is represented with a set of variables: "Total", "ContentTransfer", "Connect", "DNSLookup", "ServerProcessing", "TCPConnection". Those are packed and sent to the netchecker-server within keep-alive message using the following structure:
`
"network_probes":[
    {"URL":"http://ipinfo.io/", "Result":1, "Total":473, "ContentTransfer":0, "TCPConnection":93, "DNSLookup":99, "Connect":193, "ServerProcessing":279},
    {"URL":"http://www.kernel.org/", "Result":1, "Total":161, "ContentTransfer":162, "TCPConnection":51, "DNSLookup":39, "Connect":91, "ServerProcessing":47},
    {"URL":"http://netchecker-service:8081/api/v1/ping", "Result":1, "Total":94, "ContentTransfer":0, "TCPConnection":0, "DNSLookup":1, "Connect":2, "ServerProcessing":91}
]
`

Netchecker-server now has all the required information to provide metrics on hosts availability and timings.

Closes: https://github.com/Mirantis/k8s-netchecker-agent/issues/11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-agent/19)
<!-- Reviewable:end -->
