### PR TITLE
Extend ProbeResult with HTTPCode

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -41,7 +41,7 @@ func TestSendInfo(t *testing.T) {
 	podName := "test-pod"
 	extenderLength := 100
 	netProbes := []ProbeResult{
-		{"0.0.0.0:8081", 1, 50, 1, 0, 0, 0, 0},
+		{"0.0.0.0:8081", 1, 200, 50, 1, 0, 0, 0, 0},
 	}
 	_, err := sendInfo(serverEndPoint, podName, nodeName, netProbes, reportInterval, extenderLength, fakeClient)
 	if err != nil {


### PR DESCRIPTION
Extend ProbeResult with HTTPCode which is a result code from probe response message.
Also, rename ProbeResult.Result to ProbeResult.ConnectionResult.

Related: https://github.com/Mirantis/k8s-netchecker-agent/issues/11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-agent/22)
<!-- Reviewable:end -->
