### PR TITLE
Recognize whether connection was established and set ConnectionResult accordingly

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -193,12 +193,16 @@ func httpProbe(url string, probeRes *ProbeResult, client Client) {
 	result.End(t)
 
 	curRes.Total = int(result.Total(t) / time.Millisecond)
-	curRes.ContentTransfer = int(result.ContentTransfer(t) / time.Millisecond)
-	curRes.Connect = int(result.Connect / time.Millisecond)
-	curRes.DNSLookup = int(result.DNSLookup / time.Millisecond)
-	curRes.ServerProcessing = int(result.ServerProcessing / time.Millisecond)
-	curRes.TCPConnection = int(result.TCPConnection / time.Millisecond)
-	curRes.ConnectionResult = 1
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		// connection timeout
+	} else {
+		curRes.ConnectionResult = 1
+		curRes.ContentTransfer = int(result.ContentTransfer(t) / time.Millisecond)
+		curRes.Connect = int(result.Connect / time.Millisecond)
+		curRes.DNSLookup = int(result.DNSLookup / time.Millisecond)
+		curRes.ServerProcessing = int(result.ServerProcessing / time.Millisecond)
+		curRes.TCPConnection = int(result.TCPConnection / time.Millisecond)
+	}
 	*probeRes = *curRes
 
 	// keep variables order

--- a/agent.go
+++ b/agent.go
@@ -77,7 +77,7 @@ type ProbeResult struct {
 	ServerProcessing int
 }
 
-type ConnectionResult struct {
+type connectionResult struct {
 	Established bool
 }
 
@@ -164,7 +164,7 @@ func linkV4Info() map[string][]string {
 	return result
 }
 
-func withConnectTrace(ctx context.Context, r *ConnectionResult) context.Context {
+func withConnectTrace(ctx context.Context, r *connectionResult) context.Context {
 	return httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 		GotConn: func(i httptrace.GotConnInfo) {
 			r.Established = true
@@ -186,7 +186,7 @@ func httpProbe(url string, probeRes *ProbeResult, client Client) {
 
 	// Create go-httpstat powered context and pass it to http.Request
 	var result httpstat.Result
-	var connection ConnectionResult
+	var connection connectionResult
 	ctxStat := httpstat.WithHTTPStat(req.Context(), &result)
 	ctxStat = withConnectTrace(ctxStat, &connection)
 	req = req.WithContext(ctxStat)


### PR DESCRIPTION
Now, ConnectionResult is set to 1 only if GotConn event was received.
Also, only ProbeResult.Total value is filled in the case of timeout.

Closes: https://github.com/Mirantis/k8s-netchecker-agent/issues/24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-agent/23)
<!-- Reviewable:end -->
