### PR TITLE
Add namespace to Helm deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - 1.7.x
+  - 1.8.x
 install:
   - make get-deps
 script:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ VENDOR_DIR = vendor
 ROOT_DIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # kubeadm-dind-cluster supports k8s versions:
-# "v1.4", "v1.5" and "v1.6".
-DIND_CLUSTER_VERSION ?= v1.5
+# "v1.6", "v1.7" and "v1.8".
+DIND_CLUSTER_VERSION ?= v1.8
 
 ENV_PREPARE_MARKER = .env-prepare.complete
 BUILD_IMAGE_MARKER = .build-image.complete
@@ -37,7 +37,7 @@ BUILD_IMAGE_MARKER = .build-image.complete
 ifeq ($(DOCKER_BUILD), yes)
 	_DOCKER_GOPATH = /go
 	_DOCKER_WORKDIR = $(_DOCKER_GOPATH)/src/github.com/Mirantis/k8s-netchecker-agent/
-	_DOCKER_IMAGE  = golang:1.7
+	_DOCKER_IMAGE  = golang:1.8
 	DOCKER_DEPS = apt-get update; apt-get install -y libpcap-dev;
 	DOCKER_EXEC = docker run --rm -it -v "$(ROOT_DIR):$(_DOCKER_WORKDIR)" \
 		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE)

--- a/scripts/helm_install_and_deploy.sh
+++ b/scripts/helm_install_and_deploy.sh
@@ -27,6 +27,8 @@ HELM_DEBUG=${HELM_DEBUG:-"--debug"}
 NETCHECKER_REPO=${NETCHECKER_REPO:-}
 KUBECTL_DIR="${KUBECTL_DIR:-${HOME}/.kubeadm-dind-cluster}"
 PATH="${KUBECTL_DIR}:${PATH}"
+NS=${NS:-netchecker}
+REAL_NS="--namespace=${1:-$NS}"
 
 
 function wait-for-tiller-pod-ready() {
@@ -88,13 +90,13 @@ function lint-helm {
 function deploy-helm {
   if [ "${NETCHECKER_REPO}" == "k8s-netchecker-server" ]; then
     pushd "../${NETCHECKER_REPO}" &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_SERVER_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_SERVER_PATH}"/
     popd &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_AGENT_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_AGENT_PATH}"/
   else
-    helm "${HELM_DEBUG}" install ./"${HELM_SERVER_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_SERVER_PATH}"/
     pushd "../${NETCHECKER_REPO}" &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_AGENT_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_AGENT_PATH}"/
     popd &> /dev/null
   fi
   helm "${HELM_DEBUG}" list

--- a/scripts/kubeadm_dind_cluster.sh
+++ b/scripts/kubeadm_dind_cluster.sh
@@ -22,8 +22,8 @@ set -o nounset
 NUM_NODES=${NUM_NODES:-3}
 KUBEADM_SCRIPT_URL=${KUBEADM_SCRIPT_URL:-https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster}
 # kubeadm-dind-cluster supports k8s versions:
-# "v1.4", "v1.5" and "v1.6".
-DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.5}
+# "v1.6", "v1.7" and "v1.8".
+DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.8}
 
 
 function kubeadm-dind-cluster {


### PR DESCRIPTION
This is needed in order to properly support Kubernetes v1.8 with proper RBAC config.
Also switch build scripts/envs to use Kubernetes v1.8 and Go v1.8 to match server.